### PR TITLE
fix(klaviyo): Get phone from billing address

### DIFF
--- a/src/EventSubscriber/UpdateCustomerPropertiesFromOrderSubscriber.php
+++ b/src/EventSubscriber/UpdateCustomerPropertiesFromOrderSubscriber.php
@@ -48,10 +48,14 @@ final class UpdateCustomerPropertiesFromOrderSubscriber implements EventSubscrib
 
         $customerProperties->firstName = $address->getFirstName();
         $customerProperties->lastName = $address->getLastName();
-        try {
-            $customerProperties->phoneNumber = (string) PhoneNumber::parse($address->getPhoneNumber(), $address->getCountryCode());
-        } catch (PhoneNumberParseException) {
+        if (null === $address->getPhoneNumber()) {
             $customerProperties->phoneNumber = null;
+        } else {
+            try {
+                $customerProperties->phoneNumber = (string) PhoneNumber::parse($address->getPhoneNumber(), $address->getCountryCode());
+            } catch (PhoneNumberParseException) {
+                $customerProperties->phoneNumber = null;
+            }
         }
         $customerProperties->location = $this->propertiesFactory->create(Location::class, $address);
     }


### PR DESCRIPTION
- Fix phone number parsing from billing address

Fix error : 

```
Brick\PhoneNumber\PhoneNumber::parse(): Argument #1 ($phoneNumber) must be of type string, null given, called in /var/www/clients/client1/web1/web/vendor/setono/sylius-klaviyo-plugin/src/EventSubscriber/UpdateCustomerPropertiesFromOrderSubscriber.php on line 52
```